### PR TITLE
Allow `body` and `status` parameters

### DIFF
--- a/src/Concerns/SendsRequests.php
+++ b/src/Concerns/SendsRequests.php
@@ -70,7 +70,7 @@ trait SendsRequests
     /**
      * Issue a `GET` request to the given path.
      */
-    public function get(string $path, ?array $query = null): Response
+    public function get(string $path, array|null|string $query = null): Response
     {
         return $this->client()->get($path, $query);
     }

--- a/src/Concerns/SendsRequests.php
+++ b/src/Concerns/SendsRequests.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace RepCard\Concerns;
 
+use GuzzleHttp\Psr7\Uri;
+use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 use RepCard\RepCardService;
 
 /**
@@ -21,12 +25,37 @@ trait SendsRequests
         $this->companyId = config('repcard.company_id');
     }
 
+    public function baseUri(): Uri
+    {
+        return (new Uri())->withScheme(
+            scheme: 'https'
+        )->withHost(
+            host: config('repcard.fqdn')
+        )->withPath(
+            path: config('repcard.endpoint')
+        );
+    }
+
+    public function client(): PendingRequest
+    {
+        return Http::acceptJson()->baseUrl(
+            url: (string) $this->baseUri()
+        )->withHeader(
+            name: 'x-api-key',
+            value: config('repcard.key')
+        )->timeout(
+            seconds: config('repcard.timeout')
+        )->connectTimeout(
+            seconds: config('repcard.connect_timeout')
+        );
+    }
+
     /**
      * Issue a `GET` request to the given path.
      */
     public function get(string $path, ?array $query = null): Response
     {
-        return $this->client->get($path, $query ?? []);
+        return $this->client()->get($path, $query);
     }
 
     /**
@@ -34,7 +63,7 @@ trait SendsRequests
      */
     public function post(string $path, array $data = []): Response
     {
-        return $this->client->post($path, $data);
+        return $this->client()->post($path, $data);
     }
 
     /**
@@ -42,6 +71,6 @@ trait SendsRequests
      */
     public function put(string $path, array $data = []): Response
     {
-        return $this->client->put($path, $data);
+        return $this->client()->put($path, $data);
     }
 }

--- a/src/Concerns/SendsRequests.php
+++ b/src/Concerns/SendsRequests.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace RepCard\Concerns;
 
-use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Http\Client\Response;
 use RepCard\RepCardService;
 
@@ -15,10 +14,12 @@ use RepCard\RepCardService;
  */
 trait SendsRequests
 {
-    public function __construct(
-        protected PendingRequest $client,
-        protected int $companyId,
-    ) {}
+    protected int $companyId;
+
+    public function __construct()
+    {
+        $this->companyId = config('repcard.company_id');
+    }
 
     /**
      * Issue a `GET` request to the given path.

--- a/src/Concerns/SendsRequests.php
+++ b/src/Concerns/SendsRequests.php
@@ -25,6 +25,23 @@ trait SendsRequests
         $this->companyId = config('repcard.company_id');
     }
 
+    public function buildUrl(string $path, ?array $query = null): string
+    {
+        $url = $this->baseUri();
+
+        $url = $url->withPath(
+            path: $url->getPath().Str::start($path, '/')
+        );
+
+        if ($query !== null) {
+            $url = $url->withQuery(
+                query: http_build_query($query)
+            );
+        }
+
+        return (string) $url;
+    }
+
     public function baseUri(): Uri
     {
         return (new Uri())->withScheme(

--- a/src/Facades/RepCard.php
+++ b/src/Facades/RepCard.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace RepCard\Facades;
 
-use GuzzleHttp\Psr7\Uri;
 use Illuminate\Http\Client\Factory;
+use Illuminate\Http\Response;
 use Illuminate\Support\Facades\Facade;
 use Illuminate\Support\Facades\Http;
-use Illuminate\Support\Str;
 use RepCard\RepCardService;
 
 /**
@@ -38,30 +37,19 @@ use RepCard\RepCardService;
  */
 class RepCard extends Facade
 {
-    public static function fake(string $path, ?array $query = null): Factory
-    {
-        $instance = new Factory();
+    public static function fake(
+        string $path,
+        ?array $query = null,
+        array|null|string $body = null,
+        int $status = Response::HTTP_OK
+    ): Factory {
+        /** @var RepCardService $instance */
+        $instance = static::getFacadeRoot();
 
-        Http::swap($instance);
+        $url = $instance->buildUrl($path, $query);
 
-        $url = (new Uri())->withScheme(
-            scheme: 'https'
-        )->withHost(
-            host: config('repcard.fqdn')
-        )->withPath(
-            path: config('repcard.endpoint').Str::start($path, '/')
-        );
-
-        if ($query !== null) {
-            $url = $url->withQuery(
-                query: http_build_query($query)
-            );
-        }
-
-        $url = (string) $url;
-
-        return $instance->fake([
-            $url => Http::response(),
+        return Http::fake([
+            $url => Http::response($body, $status),
         ]);
     }
 

--- a/src/Facades/RepCard.php
+++ b/src/Facades/RepCard.php
@@ -27,7 +27,10 @@ use RepCard\RepCardService;
  * @method static \Illuminate\Http\Client\Response createUser(\RepCard\Http\Requests\UserRequest $request)
  * @method static \Illuminate\Http\Client\Response updateUser(int $userId, \RepCard\Http\Requests\UserRequest $request)
  * @method static \Illuminate\Http\Client\Response unlinkUser(int $userId)
- * @method static \Illuminate\Http\Client\Response get(string $path, array|null $query = null)
+ * @method static string buildUrl(string $path, array|null $query = null)
+ * @method static \GuzzleHttp\Psr7\Uri baseUri()
+ * @method static \Illuminate\Http\Client\PendingRequest client()
+ * @method static \Illuminate\Http\Client\Response get(string $path, array|string|null $query = null)
  * @method static \Illuminate\Http\Client\Response post(string $path, array $data = [])
  * @method static \Illuminate\Http\Client\Response put(string $path, array $data = [])
  *

--- a/src/RepCardServiceProvider.php
+++ b/src/RepCardServiceProvider.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace RepCard;
 
-use GuzzleHttp\Psr7\Uri;
 use Illuminate\Contracts\Support\DeferrableProvider;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\ServiceProvider;
 
 class RepCardServiceProvider extends ServiceProvider implements DeferrableProvider
@@ -24,25 +22,10 @@ class RepCardServiceProvider extends ServiceProvider implements DeferrableProvid
             $this->mergeConfigFrom($configPath, 'repcard');
         }
 
-        $this->app->singleton(RepCardService::class, static fn (): RepCardService => new RepCardService(
-            client: Http::acceptJson()->baseUrl(
-                url: (string) (new Uri())->withScheme(
-                    scheme: 'https'
-                )->withHost(
-                    host: config('repcard.fqdn')
-                )->withPath(
-                    path: config('repcard.endpoint')
-                )
-            )->withHeader(
-                name: 'x-api-key',
-                value: config('repcard.key')
-            )->timeout(
-                seconds: config('repcard.timeout')
-            )->connectTimeout(
-                seconds: config('repcard.connect_timeout')
-            ),
-            companyId: config('repcard.company_id')
-        ));
+        $this->app->singleton(
+            abstract: RepCardService::class,
+            concrete: static fn (): RepCardService => new RepCardService()
+        );
     }
 
     /**

--- a/tests/Facades/RepCardTest.php
+++ b/tests/Facades/RepCardTest.php
@@ -24,6 +24,55 @@ class RepCardTest extends TestCase
         ];
     }
 
+    public function test_it_can_fake_a_response(): void
+    {
+        RepCard::fake('/');
+
+        $this->assertOk(RepCard::get('/'));
+    }
+
+    public function test_it_can_build_a_url(): void
+    {
+        $url = RepCard::buildUrl('/test');
+
+        $this->assertSame('https://app.repcard.com/api/test', $url);
+    }
+
+    public function test_it_can_build_a_url_with_query(): void
+    {
+        $url = RepCard::buildUrl('/test', [
+            'foo' => 'bar',
+        ]);
+
+        $this->assertSame('https://app.repcard.com/api/test?foo=bar', $url);
+    }
+
+    public function test_it_can_get_the_base_uri(): void
+    {
+        $uri = RepCard::baseUri();
+
+        $this->assertSame('https', $uri->getScheme());
+        $this->assertSame('app.repcard.com', $uri->getHost());
+        $this->assertSame('/api', $uri->getPath());
+    }
+
+    public function test_it_can_get_the_client(): void
+    {
+        $expected = [
+            'connect_timeout' => config('repcard.connect_timeout'),
+            'http_errors' => false,
+            'timeout' => config('repcard.timeout'),
+            'headers' => [
+                'Accept' => 'application/json',
+                'x-api-key' => config('repcard.key'),
+            ],
+        ];
+
+        $options = RepCard::client()->getOptions();
+
+        $this->assertSame($expected, $options);
+    }
+
     public function test_get_companies(): void
     {
         RepCard::fake('/companies');


### PR DESCRIPTION
Updated `RepCard::fake()` method to accept `body` and `status` parameters, which will allow mocking API responses easier.