### PR TITLE
Fix `unlinkUser()` method

### DIFF
--- a/src/Concerns/Users.php
+++ b/src/Concerns/Users.php
@@ -49,6 +49,8 @@ trait Users
 
     public function unlinkUser(int $userId): Response
     {
-        return $this->post("users/$userId/unlink");
+        return $this->post("users/$userId/unlink", [
+            'assignContact' => 1,
+        ]);
     }
 }


### PR DESCRIPTION
Added required `assignContact` key-value to data.

A value of `1` indicates the user's contacts should stay with the user.
A value of `2` indicates the user's contacts should stay with the company.