### PR TITLE
Increase default `per_page` value

### DIFF
--- a/src/Concerns/Users.php
+++ b/src/Concerns/Users.php
@@ -17,7 +17,7 @@ trait Users
 {
     public function getUsers(
         ?int $companyId = null,
-        int $perPage = 30,
+        int $perPage = 100,
         int $page = 1
     ): Response {
         return $this->get('users/minimal', [

--- a/src/Facades/RepCard.php
+++ b/src/Facades/RepCard.php
@@ -20,7 +20,7 @@ use RepCard\RepCardService;
  * @method static \Illuminate\Http\Client\Response getLeaderboards(\DateTimeInterface|string|null $from = null, \DateTimeInterface|string|null $to = null)
  * @method static \Illuminate\Http\Client\Response getOffices(string|null $search = null)
  * @method static \Illuminate\Http\Client\Response getOfficeTeams(int $officeId)
- * @method static \Illuminate\Http\Client\Response getUsers(int|null $companyId = null, int $perPage = 30, int $page = 1)
+ * @method static \Illuminate\Http\Client\Response getUsers(int|null $companyId = null, int $perPage = 100, int $page = 1)
  * @method static \Illuminate\Http\Client\Response getUser(int $userId)
  * @method static \Illuminate\Http\Client\Response getEventUser(int $userId)
  * @method static \Illuminate\Http\Client\Response createUser(\RepCard\Http\Requests\UserRequest $request)

--- a/tests/Facades/RepCardTest.php
+++ b/tests/Facades/RepCardTest.php
@@ -207,7 +207,7 @@ class RepCardTest extends TestCase
 
         RepCard::fake('/users/minimal', $query = [
             'company_id' => $companyId,
-            'per_page' => 30,
+            'per_page' => 100,
             'page' => 1,
         ]);
 


### PR DESCRIPTION
Increased the default `per_page` value for `getUsers()` method from `30` to `100`, the maximum allowed.