### PR TITLE
Change encoding type

### DIFF
--- a/src/Concerns/SendsRequests.php
+++ b/src/Concerns/SendsRequests.php
@@ -35,7 +35,7 @@ trait SendsRequests
 
         if ($query !== null) {
             $url = $url->withQuery(
-                query: http_build_query($query)
+                query: http_build_query($query, encoding_type: PHP_QUERY_RFC3986),
             );
         }
 


### PR DESCRIPTION
Changed the encoding type when creating the URL query string from `PHP_QUERY_RFC1738` to `PHP_QUERY_RFC3986`, since Laravel looks for percent encoded (`%20`) and not plus (`+`) signs.